### PR TITLE
Change language package to [spanish, es-tabla]

### DIFF
--- a/Erlang/Contents-ES/Config.tex
+++ b/Erlang/Contents-ES/Config.tex
@@ -8,7 +8,7 @@
 %     If not, see <http://www.gnu.org/licenses/>.
 
 \usepackage[utf8]{inputenc}
-\usepackage[spanish]{babel} %Euskara est  en el paquete de franc s, instalar texlive-lang-french ;)
+\usepackage[spanish,es-tabla]{babel} %Euskara est  en el paquete de franc s, instalar texlive-lang-french ;)
 \usepackage{parskip}
 \usepackage{framed}
 \usepackage{xcolor}


### PR DESCRIPTION
With this options tables are called *Tabla* instead of *Cuadro* and there is no need to renew the command